### PR TITLE
docs(guides): add missing nvm commands to Node.js guide

### DIFF
--- a/src/content/guides/nodejs.mdx
+++ b/src/content/guides/nodejs.mdx
@@ -160,6 +160,9 @@ npm --version
 
 ## Uninstall Node.js
 
+> If you get an error: `nvm: Cannot uninstall currently-active node version` when
+> uninstalling any currently-active version, run `nvm deactivate` first.
+
 **Uninstall a specific version:**
 
 ```bash
@@ -171,9 +174,6 @@ nvm uninstall <node_version>
 ```bash
 nvm uninstall node
 ```
-
-> If you get an error: `nvm: Cannot uninstall currently-active node version`, you need
-> to first run `nvm deactivate` before uninstalling.
 
 **Uninstall the latest LTS version:**
 


### PR DESCRIPTION
## Summary
- Add 9 missing nvm commands to the Node.js guide

## Changes
- Updated `nodejs.mdx` with:
  - npm version verification (`npm -v`)
  - Install latest npm (`nvm install-latest-npm`)
  - Switch to LTS version (`nvm use --lts`)
  - Custom aliases (`nvm alias`, `nvm unalias`)
  - Path to node executable (`nvm which`)
  - New "Uninstall Node.js" section (`nvm uninstall` for specific, latest, and LTS versions)
  - Deactivate warning for active version uninstall

## Test plan
- [x] `bun run build` passes (astro check + build + pagefind)
- [x] Node.js guide renders correctly at `/guides/nodejs/`
- [x] New sections integrate naturally with existing content
- [ ] Visual review of guide page

## Relates Issues

- Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Node.js version management guide: add instructions for installing the latest npm, switching to LTS releases, creating/deleting custom version aliases, locating Node executables, uninstalling specific/latest/LTS Node versions, removing the version manager, and enhanced troubleshooting and cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->