### PR TITLE
fix(ci): allow repeated headings across CHANGELOG sections

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -5,6 +5,9 @@
       "code_blocks": false,
       "tables": false,
     },
+    "MD024": {
+      "siblings_only": true,
+    },
   },
   "ignores": [
     "node_modules/**",


### PR DESCRIPTION
# Pull Request

## Summary

Configure markdownlint MD024 rule with `siblings_only: true` to fix CI failures on auto-generated CHANGELOG headings.

## Changes

- Added `MD024.siblings_only: true` to `.markdownlint-cli2.jsonc`
- This permits duplicate headings (e.g. `### Features`, `### Chores`) across different version sections, which is standard changelog structure
- The rule still catches actual duplicate sibling headings within the same section

## Testing

- [x] Unit tests pass (`bun test tests/unit`)
- [x] E2E tests pass (`bunx playwright test`)
- [x] Manual testing completed
- [x] `uv run lintro chk` passes with 0 markdownlint issues

## Checklist

- [x] PR title follows [Conventional Commits][cc] format
- [x] Code builds without errors (`bun run build`)
- [x] No accessibility regressions (checked with axe-core)
- [ ] Documentation updated (if applicable)

[cc]: https://www.conventionalcommits.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Markdown linting configuration to enforce stricter standards for heading consistency across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->